### PR TITLE
refactor: rename package from rimnats to rimnats-go

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -2,7 +2,7 @@ style: github
 template: CHANGELOG.tpl.md
 info:
   title: CHANGELOG
-  repository_url: https://github.com/rimdesk/rimnats
+  repository_url: https://github.com/rimdesk/rimnats-go
 options:
   commits:
     # filters:

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go/jetstream"
-	"github.com/rimdesk/rimnats"
-	v1 "github.com/rimdesk/rimnats/gen/shooters/nexor/v1"
+	"github.com/rimdesk/rimnats-go"
+	v1 "github.com/rimdesk/rimnats-go/gen/shooters/nexor/v1"
 )
 
 var (

--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -6,7 +6,7 @@ managed:
   enabled: true
   override:
     - file_option: go_package
-      value: github.com/rimdesk/rimnats/gen/rimdesk/rimnats/v1
+      value: github.com/rimdesk/rimnats-go/gen/rimdesk/rimnats/v1
   disable:
     - file_option: go_package
       module: buf.build/googleapis/googleapis

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -7,8 +7,8 @@ import (
 	"log"
 
 	"github.com/nats-io/nats.go/jetstream"
-	"github.com/rimdesk/rimnats"
-	v1 "github.com/rimdesk/rimnats/gen/rimdesk/rimnats/v1"
+	"github.com/rimdesk/rimnats-go"
+	v1 "github.com/rimdesk/rimnats-go/gen/rimdesk/rimnats/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/examples/publisher/main.go
+++ b/examples/publisher/main.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/nats-io/nats.go/jetstream"
-	"github.com/rimdesk/rimnats"
-	v1 "github.com/rimdesk/rimnats/gen/rimdesk/rimnats/v1"
+	"github.com/rimdesk/rimnats-go"
+	v1 "github.com/rimdesk/rimnats-go/gen/rimdesk/rimnats/v1"
 )
 
 var (

--- a/examples/reply/main.go
+++ b/examples/reply/main.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/rimdesk/rimnats"
-	v1 "github.com/rimdesk/rimnats/gen/shooters/nexor/v1"
+	"github.com/rimdesk/rimnats-go-go"
+	v1 "github.com/rimdesk/rimnats-go/gen/shooters/nexor/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/examples/request/main.go
+++ b/examples/request/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/rimdesk/rimnats"
-	v1 "github.com/rimdesk/rimnats/gen/shooters/nexor/v1"
+	"github.com/rimdesk/rimnats-go"
+	v1 "github.com/rimdesk/rimnats-go/gen/shooters/nexor/v1"
 	"google.golang.org/protobuf/proto"
 )
 

--- a/gen/rimdesk/rimnats/v1/rimnats.pb.go
+++ b/gen/rimdesk/rimnats/v1/rimnats.pb.go
@@ -247,8 +247,8 @@ const file_rimdesk_rimnats_v1_rimnats_proto_rawDesc = "" +
 	"\x0fSayHelloRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\",\n" +
 	"\x10SayHelloResponse\x12\x18\n" +
-	"\amessage\x18\x01 \x01(\tR\amessageB\xc3\x01\n" +
-	"\x16com.rimdesk.rimnats.v1B\fRimnatsProtoP\x01Z1github.com/rimdesk/rimnats/gen/rimdesk/rimnats/v1\xa2\x02\x03RRX\xaa\x02\x12Rimdesk.Rimnats.V1\xca\x02\x12Rimdesk\\Rimnats\\V1\xe2\x02\x1eRimdesk\\Rimnats\\V1\\GPBMetadata\xea\x02\x14Rimdesk::Rimnats::V1b\x06proto3"
+	"\amessage\x18\x01 \x01(\tR\amessageB\xc6\x01\n" +
+	"\x16com.rimdesk.rimnats.v1B\fRimnatsProtoP\x01Z4github.com/rimdesk/rimnats-go/gen/rimdesk/rimnats/v1\xa2\x02\x03RRX\xaa\x02\x12Rimdesk.Rimnats.V1\xca\x02\x12Rimdesk\\Rimnats\\V1\xe2\x02\x1eRimdesk\\Rimnats\\V1\\GPBMetadata\xea\x02\x14Rimdesk::Rimnats::V1b\x06proto3"
 
 var (
 	file_rimdesk_rimnats_v1_rimnats_proto_rawDescOnce sync.Once

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rimdesk/rimnats
+module github.com/rimdesk/rimnats-go
 
 go 1.24
 


### PR DESCRIPTION
Update import paths in all files to reflect the new module name. Update references in configuration files like buf.gen.yaml and .chglog/config.yml.