### PR TITLE
Feat/update example subjects to product

### DIFF
--- a/.idea/go.imports.xml
+++ b/.idea/go.imports.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GoImports">
+    <option name="excludedPackages">
+      <array>
+        <option value="github.com/pkg/errors" />
+        <option value="golang.org/x/net/context" />
+      </array>
+    </option>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/consumer.go
+++ b/consumer.go
@@ -5,7 +5,6 @@ package rimnats
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"github.com/nats-io/nats.go/jetstream"
@@ -65,6 +64,7 @@ func (n *rimNats) Subscribe(
 		FilterSubject: subject,
 	})
 	if err != nil {
+		n.loggR.Error("🚨 [ rimnats ]: failed to create consumer: %v", err)
 		return err
 	}
 
@@ -74,7 +74,7 @@ func (n *rimNats) Subscribe(
 		msg := factory()
 		if err := proto.Unmarshal(m.Data(), msg); err != nil {
 			if n.cfg.Debug {
-				log.Printf("🚨 rimnats: failed to decode protobuf: %v", err)
+				n.loggR.Info("🚨 [ rimnats ]: failed to decode protobuf: %v", err)
 			}
 
 			_ = m.Nak() // NACK to let NATS know we couldn't process the message
@@ -84,7 +84,7 @@ func (n *rimNats) Subscribe(
 		// Call the handler to process the message
 		if err := handler(ctx, msg, m); err != nil {
 			if n.cfg.Debug {
-				log.Printf("🚨 rimnats: handler error: %v", err)
+				n.loggR.Info("🚨 [ rimnats ]: handler error: %v", err)
 			}
 
 			_ = m.Nak() // NACK if the handler fails
@@ -94,13 +94,13 @@ func (n *rimNats) Subscribe(
 
 	if err != nil {
 		if n.cfg.Debug {
-			log.Printf("❌ rimnats: failed to subscribe to subject: %s: %v", subject, err)
+			n.loggR.Info("❌ [ rimnats ]: failed to subscribe to subject: %s: %v", subject, err)
 		}
 		return err
 	}
 
 	if n.cfg.Debug {
-		log.Printf("🚀 rimnats: successfully subscribed to subject: %s", subject)
+		n.loggR.Info("🚀 [ rimnats ]: successfully subscribed to subject: %s", subject)
 	}
 
 	return err

--- a/examples/consumer/main.go
+++ b/examples/consumer/main.go
@@ -27,7 +27,7 @@ func main() {
 	ctx := context.Background()
 
 	// Subscribe to the "product.created" event
-	err := client.Subscribe(ctx, "sample.created", "product_stream", "product_service",
+	err := client.Subscribe(ctx, "product.created", "product_stream", "product_service",
 		func() proto.Message {
 			return &v1.Event{} // Factory method to create a specific event type
 		}, func(ctx context.Context, msg proto.Message, m jetstream.Msg) error {

--- a/examples/publisher/main.go
+++ b/examples/publisher/main.go
@@ -30,7 +30,7 @@ func main() {
 	if err := client.CreateStream(ctx, jetstream.StreamConfig{
 		Name:        "product_stream",
 		Description: "Sample events",
-		Subjects:    []string{"sample.>"},
+		Subjects:    []string{"product.>"},
 		MaxBytes:    1024 * 1024 * 1024,
 	}); err != nil {
 		log.Println("🚨 [RIMNats]: Failed to initialize event bus:", err)
@@ -43,7 +43,7 @@ func main() {
 
 		// List of sample words
 		words := []string{"Apple", "Banana", "Orange", "Mango", "Grape", "Peach", "Plum", "Cherry", "Lemon", "Lime"}
-		subjects := []string{"sample.created", "sample.updated"}
+		subjects := []string{"product.created", "product.updated"}
 
 		// Generate a random word
 		randomWord := words[currentTime.UnixNano()%int64(len(words))]

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,11 @@ require (
 )
 
 require (
+	github.com/beego/beego/v2 v2.3.8 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/nats-io/nkeys v0.4.11 // indirect
 	github.com/nats-io/nuid v1.0.1 // indirect
+	github.com/shiena/ansicolor v0.0.0-20200904210342-c7312218db18 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/beego/beego/v2 v2.3.8 h1:wplhB1pF4TxR+2SS4PUej8eDoH4xGfxuHfS7wAk9VBc=
+github.com/beego/beego/v2 v2.3.8/go.mod h1:8vl9+RrXqvodrl9C8yivX1e6le6deCK6RWeq8R7gTTg=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
@@ -10,6 +12,8 @@ github.com/nats-io/nkeys v0.4.11 h1:q44qGV008kYd9W1b1nEBkNzvnWxtRSQ7A8BoqRrcfa0=
 github.com/nats-io/nkeys v0.4.11/go.mod h1:szDimtgmfOi9n25JpfIdGw12tZFYXqhGxjhVxsatHVE=
 github.com/nats-io/nuid v1.0.1 h1:5iA8DT8V7q8WK2EScv2padNa/rTESc1KdnPw4TC2paw=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/shiena/ansicolor v0.0.0-20200904210342-c7312218db18 h1:DAYUYH5869yV94zvCES9F51oYtN5oGlwjxJJz7ZCnik=
+github.com/shiena/ansicolor v0.0.0-20200904210342-c7312218db18/go.mod h1:nkxAfR/5quYxwPZhyDxgasBMnRtBZd0FCEpawpjMUFg=
 golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=
 golang.org/x/crypto v0.41.0/go.mod h1:pO5AFd7FA68rFak7rOAGVuygIISepHftHnr8dr6+sUc=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=

--- a/publisher.go
+++ b/publisher.go
@@ -2,7 +2,6 @@ package rimnats
 
 import (
 	"context"
-	"log"
 
 	"github.com/nats-io/nats.go/jetstream"
 	"google.golang.org/protobuf/proto"
@@ -23,7 +22,7 @@ func (n *rimNats) Publish(ctx context.Context, subject string, msg proto.Message
 	data, err := proto.Marshal(msg)
 	if err != nil {
 		if n.cfg.Debug {
-			log.Printf("❌ rimnats: failed to encode protobuf: %v", err)
+			n.loggR.Info("❌ [ rimnats ]: failed to encode protobuf: %v", err)
 		}
 
 		return err
@@ -32,17 +31,17 @@ func (n *rimNats) Publish(ctx context.Context, subject string, msg proto.Message
 	ack, err := n.js.Publish(ctx, subject, data, opts...)
 	if err != nil {
 		if n.cfg.Debug {
-			log.Printf("❌ rimnats: failed to publish message: %v", err)
+			n.loggR.Info("❌ [ rimnats ]: failed to publish message: %v", err)
 		}
 
 		return err
 	}
 
 	if n.cfg.Debug {
-		log.Printf("🚀 rimnats: published message on domain: %s", ack.Domain)
-		log.Printf("🚀 rimnats: published message on sequence: %d", ack.Sequence)
-		log.Printf("🚀 rimnats: published message on duplicate: %v", ack.Duplicate)
-		log.Printf("🚀 rimnats: published message on stream: %s", ack.Stream)
+		n.loggR.Info("🚀 [ rimnats ]: published message on domain: %s", ack.Domain)
+		n.loggR.Info("🚀 [ rimnats ]: published message on sequence: %d", ack.Sequence)
+		n.loggR.Info("🚀 [ rimnats ]: published message on duplicate: %v", ack.Duplicate)
+		n.loggR.Info("🚀 [ rimnats ]: published message on stream: %s", ack.Stream)
 	}
 
 	return err

--- a/reply.go
+++ b/reply.go
@@ -2,7 +2,6 @@ package rimnats
 
 import (
 	"context"
-	"log"
 
 	"github.com/nats-io/nats.go"
 	"google.golang.org/protobuf/proto"
@@ -17,7 +16,7 @@ func (n *rimNats) Reply(subject string, reqFactory func() proto.Message, handler
 		req := reqFactory()
 		if err := proto.Unmarshal(m.Data, req); err != nil {
 			if n.cfg.Debug {
-				log.Printf("❌ rimnats: failed to unmarshal request: %v", err)
+				n.loggR.Error("❌ [ rimnats ]: failed to unmarshal request: %v", err)
 			}
 			return
 		}
@@ -25,7 +24,7 @@ func (n *rimNats) Reply(subject string, reqFactory func() proto.Message, handler
 		resp, err := handler(context.Background(), req)
 		if err != nil {
 			if n.cfg.Debug {
-				log.Printf("❌ rimnats: request handler failed: %v", err)
+				n.loggR.Error("❌ [ rimnats ]: request handler failed: %v", err)
 			}
 			// Optionally send an error message (could serialize error into protobuf)
 			_ = m.Respond([]byte{})
@@ -35,7 +34,7 @@ func (n *rimNats) Reply(subject string, reqFactory func() proto.Message, handler
 		data, err := proto.Marshal(resp)
 		if err != nil {
 			if n.cfg.Debug {
-				log.Printf("❌ rimnats: failed to marshal response: %v", err)
+				n.loggR.Error("❌ [ rimnats ]: failed to marshal response: %v", err)
 			}
 			return
 		}
@@ -44,7 +43,7 @@ func (n *rimNats) Reply(subject string, reqFactory func() proto.Message, handler
 	})
 
 	if err != nil && n.cfg.Debug {
-		log.Printf("❌ rimnats: failed to subscribe for reply on %s: %v", subject, err)
+		n.loggR.Error("❌ [ rimnats ]: failed to subscribe for reply on %s: %v", subject, err)
 	}
 
 	return err

--- a/request.go
+++ b/request.go
@@ -2,7 +2,6 @@ package rimnats
 
 import (
 	"context"
-	"log"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -17,7 +16,7 @@ func (n *rimNats) Request(ctx context.Context, subject string, req proto.Message
 	data, err := proto.Marshal(req)
 	if err != nil {
 		if n.cfg.Debug {
-			log.Printf("❌ rimnats: failed to marshal request: %v", err)
+			n.loggR.Error("❌ [ rimnats ]: failed to marshal request: %v", err)
 		}
 		return nil, err
 	}
@@ -25,7 +24,7 @@ func (n *rimNats) Request(ctx context.Context, subject string, req proto.Message
 	msg, err := n.conn.RequestWithContext(ctx, subject, data)
 	if err != nil {
 		if n.cfg.Debug {
-			log.Printf("❌ rimnats: request error: %v", err)
+			n.loggR.Error("❌ [ rimnats ]: request error: %v", err)
 		}
 		return nil, err
 	}
@@ -33,7 +32,7 @@ func (n *rimNats) Request(ctx context.Context, subject string, req proto.Message
 	reply := factory()
 	if err := proto.Unmarshal(msg.Data, reply); err != nil {
 		if n.cfg.Debug {
-			log.Printf("❌ rimnats: failed to unmarshal response: %v", err)
+			n.loggR.Error("❌ [ rimnats ]: failed to unmarshal response: %v", err)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
refactor(rimnats): migrate logging to Beego BeeLogger and standardize log output

- Replace stdlib `log` with Beego `logs.BeeLogger` across `client`, `consumer`, `publisher`, `reply`, and `request`
- Add `loggR *logs.BeeLogger` to `rimNats` and initialize via new `getLogger()` helper
- Standardize messages and levels (`Info`/`Error`) for connect, publish, subscribe, request/reply flows
- Create stream errors now logged with BeeLogger
- Minor interface reordering (no behavioral change)
- Update dependencies:
  - add `github.com/beego/beego/v2 v2.3.8` (indirect)
  - add `github.com/shiena/ansicolor` (indirect)
  - refresh `go.sum`
- IDE: enable commit message inspection in `.idea/vcs.xml`

No breaking changes; public API semantics unchanged.